### PR TITLE
fix: guard cast list when copying details

### DIFF
--- a/src/components/DetailCard.tsx
+++ b/src/components/DetailCard.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { MediaDetails } from "../types";
+import { MediaDetails, HistoryItem } from "../types";
 import {
   Star,
   Calendar,
   Clock,
-  Users,
   PlayCircle,
   Globe,
   Copy,
@@ -26,7 +25,7 @@ const DetailCard: React.FC<{ details: MediaDetails }> = ({ details }) => {
 
   useEffect(() => {
     const savedHistory = localStorage.getItem("movieTvHistory");
-    const history = savedHistory ? JSON.parse(savedHistory) : [];
+    const history: HistoryItem[] = savedHistory ? JSON.parse(savedHistory) : [];
     const newItem = {
       id: details.id,
       title: isMovie ? details.title : details.name,
@@ -37,7 +36,7 @@ const DetailCard: React.FC<{ details: MediaDetails }> = ({ details }) => {
     };
     const newHistory = [
       newItem,
-      ...history.filter((item: any) => item.id !== newItem.id),
+      ...history.filter((item) => item.id !== newItem.id),
     ].slice(0, 20);
     localStorage.setItem("movieTvHistory", JSON.stringify(newHistory));
   }, [details, isMovie]);
@@ -45,9 +44,9 @@ const DetailCard: React.FC<{ details: MediaDetails }> = ({ details }) => {
   const copyDetails = () => {
     // Menyiapkan daftar pemeran untuk disalin
     const castInfo = details.credits?.cast
-      .slice(0, 5) // Ambil 5 pemeran utama
-      .map((actor) => `${actor.name} as ${actor.character}`)
-      .join("\n"); // Pisahkan dengan baris baru
+      ?.slice(0, 5) // Ambil 5 pemeran utama
+      ?.map((actor) => `${actor.name} as ${actor.character}`)
+      ?.join("\n"); // Pisahkan dengan baris baru
 
     const title = (isMovie ? details.title : details.name) || "";
     const detailsText = `

--- a/src/components/MediaRow.tsx
+++ b/src/components/MediaRow.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { MediaItem } from "../types";
-import { Film, Tv } from "lucide-react";
 
 interface MediaRowProps {
   title: string;

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -7,7 +7,6 @@ interface SearchFormProps {
 
 const SearchForm: React.FC<SearchFormProps> = ({ onSearch }) => {
   const [query, setQuery] = useState("");
-  const type = "multi"; // Tipe pencarian bisa disederhanakan untuk header
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Film, Tv, Calendar } from "lucide-react";
+import { Calendar } from "lucide-react";
 import { SearchResult } from "../types";
 
 interface SearchResultsProps {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -20,8 +20,8 @@ const SearchPage: React.FC = () => {
       try {
         const data = await apiFetch(`/search/multi`, { query });
         setResults(
-          data.results.filter(
-            (r: any) => r.media_type === "movie" || r.media_type === "tv"
+          (data.results as SearchResult[]).filter(
+            (r) => r.media_type === "movie" || r.media_type === "tv"
           )
         );
       } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface MediaDetails extends MediaItem {
 }
 
 // Tipe untuk hasil pencarian
-export interface SearchResult extends MediaItem {}
+export type SearchResult = MediaItem;
 
 // Tipe untuk item di riwayat
 export interface HistoryItem extends MediaItem {


### PR DESCRIPTION
## Summary
- avoid runtime error when copying details without available cast
- clean up types and imports for lint compliance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689748d964ec832a989f517ac06f0d99