### PR TITLE
fix: guard provider results access

### DIFF
--- a/src/components/DetailCard.tsx
+++ b/src/components/DetailCard.tsx
@@ -22,7 +22,7 @@ const DetailCard: React.FC<{ details: MediaDetails }> = ({ details }) => {
   const trailer = details.videos?.results.find(
     (v) => v.type === "Trailer" && v.site === "YouTube"
   );
-  const providers = details["watch/providers"]?.results.ID;
+  const providers = details["watch/providers"]?.results?.ID;
 
   useEffect(() => {
     const savedHistory = localStorage.getItem("movieTvHistory");


### PR DESCRIPTION
## Summary
- prevent undefined access when reading provider results

## Testing
- `npm run build`
- `npm run lint` *(fails: Users is defined but never used, Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68974a2b4490832a931f1d15784f2654