### PR TITLE
Add tools page with navigation link

### DIFF
--- a/public/tools.html
+++ b/public/tools.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Universal Link Generator</title>
+  <style>
+    body { font-family: sans-serif; max-width: 600px; margin: 2rem auto; padding: 0 1rem; }
+    h1 { margin-bottom: 1rem; }
+    label { display:block; margin-top:1rem; }
+    input { width:100%; padding:0.5rem; margin-top:0.25rem; }
+    button { margin-top:1rem; padding:0.5rem 1rem; }
+    pre { background:#f4f4f4; padding:1rem; margin-top:1rem; word-break:break-all; }
+  </style>
+</head>
+<body>
+  <h1>Universal Link Generator</h1>
+  <label>Base URL
+    <input id="base" placeholder="https://example.com" />
+  </label>
+  <label>Path
+    <input id="path" placeholder="/path" />
+  </label>
+  <button id="generate">Generate</button>
+  <pre id="output"></pre>
+
+  <script>
+    const base = document.getElementById('base');
+    const path = document.getElementById('path');
+    const output = document.getElementById('output');
+    document.getElementById('generate').addEventListener('click', () => {
+      const url = `${base.value.replace(/\/$/, '')}${path.value.startsWith('/') ? '' : '/'}${path.value}`;
+      output.textContent = url;
+    });
+  </script>
+</body>
+</html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,6 +37,12 @@ const Header: React.FC = () => {
             <NavLink to="/discover/tv" className={navLinkClass}>
               Acara TV
             </NavLink>
+            <a
+              href="/tools.html"
+              className="pb-1 border-b-2 border-transparent text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+            >
+              Tools
+            </a>
           </nav>
         </div>
         <div className="w-full md:w-auto flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add standalone Tools page with a simple universal link generator
- link Tools page from main header navigation

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*
- `npm run dev -- --host 127.0.0.1 --clearScreen false`
- `curl -s http://127.0.0.1:5173/tools.html | head`


------
https://chatgpt.com/codex/tasks/task_e_689751f59f2c832ab3529032b3849473