### PR TITLE
Add tools page with navigation link

### DIFF
--- a/public/tools.html
+++ b/public/tools.html
@@ -1,0 +1,660 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Universal Link Generator</title>
+  <script>
+    tailwind.config = {
+      darkMode: "class",
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'sans-serif'],
+            display: ['"Bebas Neue"', 'cursive'],
+          },
+          colors: {
+            'brand-background': '#0D1117',
+            'brand-surface': '#161B22',
+            'brand-border': '#30363D',
+            'brand-primary': '#8B5CF6',
+            'brand-secondary': '#EC4899',
+            'brand-text-primary': '#E6EDF3',
+            'brand-text-secondary': '#7D8590',
+          },
+        },
+      },
+    };
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Bebas+Neue&display=swap" rel="stylesheet" />
+  <style>
+    body { @apply bg-brand-background text-brand-text-primary font-sans; }
+    .btn { @apply inline-flex items-center justify-center px-4 py-2 rounded-lg font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-brand-primary; }
+    .btn-primary { @apply bg-brand-primary text-white hover:bg-brand-secondary disabled:bg-brand-border disabled:cursor-not-allowed; }
+    .btn-secondary { @apply bg-brand-surface text-brand-text-secondary hover:bg-brand-border; }
+    .btn-danger { @apply bg-red-600 text-white hover:bg-red-700; }
+    .input-field { @apply block w-full rounded-lg bg-brand-background border-brand-border text-brand-text-primary shadow-sm focus:border-brand-primary focus:ring-brand-primary sm:text-sm transition-colors duration-200; }
+    .card { @apply bg-brand-surface p-6 rounded-xl shadow-lg border border-brand-border; }
+    .card-header { @apply flex items-center gap-3 mb-4 border-b border-brand-border pb-3; }
+    .card-header-icon { @apply w-8 h-8 flex items-center justify-center bg-brand-primary/20 text-brand-primary rounded-lg; }
+    .toast { @apply fixed top-5 right-5 flex items-center gap-3 px-6 py-3 rounded-xl text-white shadow-2xl transition-all duration-300 translate-x-[150%]; }
+    .toast.show { @apply translate-x-0; }
+    .toast-success { @apply bg-green-600; }
+    .toast-error { @apply bg-red-600; }
+    .toast-warning { @apply bg-amber-500 text-black; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .loader { @apply inline-block w-5 h-5 border-[3px] border-t-white border-r-transparent border-b-transparent border-l-transparent rounded-full; animation: spin 0.8s linear infinite; }
+  </style>
+</head>
+<body>
+  <div id="toast-container" class="fixed top-5 right-5 z-50 space-y-3"></div>
+
+  <header class="py-4 px-4 md:px-8 border-b border-brand-border sticky top-0 bg-brand-background/80 backdrop-blur-lg z-50">
+    <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
+      <div class="flex items-center gap-8">
+        <a href="/" class="flex items-center gap-3 flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-brand-primary">
+            <rect width="18" height="18" x="3" y="3" rx="2" />
+            <path d="M7 3v18" />
+            <path d="M3 7.5h4" />
+            <path d="M3 12h18" />
+            <path d="M3 16.5h4" />
+            <path d="M17 3v18" />
+            <path d="M17 7.5h4" />
+            <path d="M17 16.5h4" />
+          </svg>
+          <span class="text-3xl font-display text-brand-text-primary tracking-wider">CineScope</span>
+        </a>
+        <nav class="hidden md:flex items-center gap-6 text-sm font-semibold">
+          <a href="/discover/movie" class="pb-1 border-b-2 border-transparent text-brand-text-secondary hover:text-brand-text-primary transition-colors">Film</a>
+          <a href="/discover/tv" class="pb-1 border-b-2 border-transparent text-brand-text-secondary hover:text-brand-text-primary transition-colors">Acara TV</a>
+          <a href="/tools.html" class="pb-1 border-b-2 border-brand-primary text-brand-text-primary">Tools</a>
+        </nav>
+      </div>
+      <div class="w-full md:w-auto flex items-center gap-2">
+        <div class="w-full md:w-72">
+          <input type="text" placeholder="Search..." class="w-full px-3 py-2 rounded-lg bg-brand-surface border border-brand-border focus:outline-none focus:ring-2 focus:ring-brand-primary" />
+        </div>
+        <a href="/watchlist" title="Watchlist" class="p-2.5 rounded-lg hover:bg-brand-surface transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
+          </svg>
+        </a>
+        <a href="/history" title="History" class="p-2.5 rounded-lg hover:bg-brand-surface transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+            <path d="M3 3v5h5" />
+            <path d="M12 7v5l4 2" />
+          </svg>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto p-4 md:p-8">
+    <header class="text-center mb-10">
+      <h1 class="text-4xl md:text-5xl font-extrabold text-brand-text-primary">Universal Link Generator</h1>
+      <p class="text-brand-text-secondary mt-3 text-lg">Buat & kelola link Anda dengan mudah dan cepat.</p>
+    </header>
+
+    <!-- Main Grid -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+
+            <!-- Left Column: Inputs -->
+            <div class="flex flex-col gap-8">
+                <!-- Global Settings & Session -->
+                <div class="card">
+                    <div class="card-header">
+                        <div class="card-header-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0L7.86 6.83c-.35.14-.69.33-.99.57l-3.54-1.59c-1.44-.65-2.98.89-2.33 2.33l1.59 3.54c.24.3.43.64.57.99l-3.66.65c-1.56.38-1.56 2.6 0 2.98l3.66.65c-.14.35-.33.69-.57.99l-1.59 3.54c-.65 1.44.89 2.98 2.33 2.33l3.54-1.59c.3-.24.64-.43.99-.57l.65 3.66c.38 1.56 2.6 1.56 2.98 0l.65-3.66c.35-.14.69-.33.99-.57l3.54 1.59c1.44.65 2.98-.89 2.33-2.33l-1.59-3.54a4.96 4.96 0 00-.57-.99l3.66-.65c1.56-.38 1.56-2.6 0-2.98l-3.66-.65c.14-.35.33-.69.57-.99l1.59-3.54c.65-1.44-.89-2.98-2.33-2.33l-3.54 1.59a4.96 4.96 0 00-.99-.57L11.49 3.17zm-1.49 6.33a2.5 2.5 0 100 5 2.5 2.5 0 000-5z" clip-rule="evenodd" /></svg>
+                        </div>
+                        <h2 class="text-xl font-bold text-brand-text-primary">Pengaturan Global & Sesi</h2>
+                    </div>
+                    <div class="space-y-4">
+                        <div>
+                            <label for="ouo-api-key" class="block text-sm font-medium text-brand-text-secondary mb-1">API Key ouo.io</label>
+                            <input type="password" id="ouo-api-key" value="8pHuHRq5" class="input-field" placeholder="Masukkan API Key Anda">
+                        </div>
+                        <div class="flex flex-wrap gap-3 pt-2">
+                            <button id="save-session-btn" class="btn btn-secondary text-sm">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor"><path d="M5.5 16a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 16h-8z" /></svg>
+                                Simpan Sesi
+                            </button>
+                            <label for="load-session-file" class="btn btn-secondary text-sm cursor-pointer">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clip-rule="evenodd" /></svg>
+                                Muat Sesi
+                            </label>
+                            <input type="file" id="load-session-file" class="hidden" accept=".json">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Input Data Card -->
+                <div class="card">
+                    <div class="card-header">
+                        <div class="card-header-icon">
+                           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path d="M17.414 2.586a2 2 0 00-2.828 0L7 10.172V13h2.828l7.586-7.586a2 2 0 000-2.828z" /><path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" clip-rule="evenodd" /></svg>
+                        </div>
+                        <h2 class="text-xl font-bold text-brand-text-primary">1. Input Data</h2>
+                    </div>
+                    <div class="space-y-5">
+                        <!-- Input Mode -->
+                        <div class="flex items-center gap-4">
+                             <label class="text-sm font-medium text-brand-text-secondary">Mode Input:</label>
+                             <div class="flex gap-4">
+                                <div>
+                                    <input type="radio" id="mode-batch" name="input_mode" value="batch" class="h-4 w-4 text-brand-primary border-slate-300 focus:ring-brand-primary" checked>
+                                    <label for="mode-batch" class="ml-2 text-sm text-brand-text-secondary">Batch Episode</label>
+                                </div>
+                                <div>
+                                    <input type="radio" id="mode-single" name="input_mode" value="single" class="h-4 w-4 text-brand-primary border-slate-300 focus:ring-brand-primary">
+                                    <label for="mode-single" class="ml-2 text-sm text-brand-text-secondary">Single Link</label>
+                                </div>
+                             </div>
+                        </div>
+
+                        <!-- Episode Range (Batch Mode Only) -->
+                        <div id="episode-range-container" class="grid grid-cols-2 gap-4">
+                            <div>
+                                <label for="start-ep" class="block text-sm font-medium text-brand-text-secondary">Mulai dari Episode</label>
+                                <input type="number" id="start-ep" value="1" min="1" class="input-field mt-1">
+                            </div>
+                            <div>
+                                <label for="end-ep" class="block text-sm font-medium text-brand-text-secondary">Sampai Episode</label>
+                                <input type="number" id="end-ep" value="1" min="1" class="input-field mt-1">
+                            </div>
+                        </div>
+
+                        <!-- Streaming Links -->
+                        <div>
+                            <label for="stream-links" class="block text-sm font-medium text-brand-text-secondary">Link Streaming (Opsional)</label>
+                            <textarea id="stream-links" rows="3" class="input-field mt-1" placeholder="1 link per baris untuk mode batch"></textarea>
+                        </div>
+
+                        <!-- Resolutions -->
+                        <div>
+                            <label class="block text-sm font-medium text-brand-text-secondary">Resolusi Download</label>
+                            <div id="resolution-options" class="grid grid-cols-3 sm:grid-cols-5 gap-2 mt-2"></div>
+                        </div>
+
+                        <!-- Server Name -->
+                        <div>
+                             <label for="server-name-select" class="block text-sm font-medium text-brand-text-secondary">Nama Server Download</label>
+                             <div class="flex gap-2 mt-1">
+                                <select id="server-name-select" class="input-field flex-grow"></select>
+                                <input type="text" id="server-name-manual" class="input-field flex-grow" placeholder="Ketik Manual...">
+                             </div>
+                        </div>
+
+                        <!-- Download Links -->
+                        <div>
+                            <label for="download-links" class="block text-sm font-medium text-brand-text-secondary">Link Download</label>
+                            <textarea id="download-links" rows="5" class="input-field mt-1" placeholder="Urutan: Ep1-Res1, Ep1-Res2, Ep2-Res1, ..."></textarea>
+                        </div>
+                        
+                        <!-- Action Buttons -->
+                        <div class="flex gap-3 pt-2">
+                            <button id="add-data-btn" class="btn btn-primary w-full gap-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" /></svg>
+                                Tambah Data
+                            </button>
+                            <button id="reset-all-btn" class="btn btn-danger w-full gap-2">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 110 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" /></svg>
+                                Reset Semua
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right Column: Settings & Results -->
+            <div class="flex flex-col gap-8">
+                <div class="card">
+                     <div class="card-header">
+                        <div class="card-header-icon">
+                           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path d="M10 12a2 2 0 100-4 2 2 0 000 4z" /><path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.022 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd" /></svg>
+                        </div>
+                        <h2 class="text-xl font-bold text-brand-text-primary">2. Pengaturan & Hasil</h2>
+                    </div>
+                    
+                    <!-- Server List -->
+                    <div id="server-list-container" class="space-y-3 mb-6">
+                        <p id="no-data-msg" class="text-brand-text-secondary text-center py-4">Belum ada data yang ditambahkan.</p>
+                    </div>
+                    
+                    <!-- Output Format -->
+                    <div id="output-settings-container" class="hidden">
+                        <h3 class="text-lg font-semibold mb-4 text-brand-text-secondary">Pilih Format Output</h3>
+                        <div class="space-y-4">
+                            <div id="format-options-radio" class="flex flex-wrap gap-x-6 gap-y-2"></div>
+                            <div id="format-specific-options" class="p-4 bg-brand-background/80 rounded-lg border border-brand-border"></div>
+                        </div>
+                        <button id="generate-html-btn" class="btn btn-primary w-full mt-6 gap-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414l-3 3a1 1 0 01-1.414-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>
+                            Generate HTML
+                        </button>
+                    </div>
+
+                    <!-- Result Display -->
+                    <div id="result-container" class="hidden mt-6">
+                        <h3 class="text-lg font-semibold mb-2 text-brand-text-secondary">Hasil HTML</h3>
+                        <div class="relative">
+                            <textarea id="result-html" readonly class="w-full h-48 p-3 bg-brand-background text-emerald-400 font-mono text-sm rounded-lg border border-brand-border focus:outline-none focus:ring-2 focus:ring-brand-primary"></textarea>
+                            <button id="copy-html-btn" class="absolute top-2.5 right-2.5 bg-brand-border hover:bg-brand-surface text-white p-1.5 rounded-md" title="Salin HTML">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path d="M7 9a2 2 0 012-2h6a2 2 0 012 2v6a2 2 0 01-2 2H9a2 2 0 01-2-2V9z" /><path d="M5 3a2 2 0 00-2 2v6a2 2 0 002 2V5h6a2 2 0 00-2-2H5z" /></svg>
+                            </button>
+                        </div>
+                        <h3 class="text-lg font-semibold mt-4 mb-2 text-brand-text-secondary">Preview</h3>
+                        <div id="result-preview" class="p-4 border border-brand-border rounded-lg bg-brand-surface h-64 overflow-y-auto"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // --- STATE MANAGEMENT ---
+            let state = {
+                mainData: {}, serverOrder: [], selectedResolutions: ["480p", "720p"], startEp: 1, endEp: 1,
+            };
+
+            // --- CONSTANTS & OPTIONS ---
+            const SERVER_OPTIONS = ["(Ketik Manual)", "Mirrored", "TeraBox", "UpFiles", "BuzzHeav", "AkiraBox", "SendNow", "KrakrnFl", "Vidguard", "StreamHG"];
+            const RESOLUTION_OPTIONS = ["360p", "480p", "540p", "720p", "1080p"];
+            const OUTPUT_FORMATS = { drakor: "Format Drakor", ringkas: "Format Ringkas", resolusi: "Format Resolusi per Baris" };
+
+            // --- DOM ELEMENTS ---
+            const ouoApiKeyInput = document.getElementById('ouo-api-key');
+            const inputModeRadios = document.querySelectorAll('input[name="input_mode"]');
+            const episodeRangeContainer = document.getElementById('episode-range-container');
+            const startEpInput = document.getElementById('start-ep');
+            const endEpInput = document.getElementById('end-ep');
+            const streamLinksInput = document.getElementById('stream-links');
+            const resolutionOptionsContainer = document.getElementById('resolution-options');
+            const serverNameSelect = document.getElementById('server-name-select');
+            const serverNameManual = document.getElementById('server-name-manual');
+            const downloadLinksInput = document.getElementById('download-links');
+            const addDataBtn = document.getElementById('add-data-btn');
+            const resetAllBtn = document.getElementById('reset-all-btn');
+            const serverListContainer = document.getElementById('server-list-container');
+            const noDataMsg = document.getElementById('no-data-msg');
+            const outputSettingsContainer = document.getElementById('output-settings-container');
+            const formatOptionsRadio = document.getElementById('format-options-radio');
+            const formatSpecificOptions = document.getElementById('format-specific-options');
+            const generateHtmlBtn = document.getElementById('generate-html-btn');
+            const resultContainer = document.getElementById('result-container');
+            const resultHtmlTextarea = document.getElementById('result-html');
+            const copyHtmlBtn = document.getElementById('copy-html-btn');
+            const resultPreview = document.getElementById('result-preview');
+            const saveSessionBtn = document.getElementById('save-session-btn');
+            const loadSessionFile = document.getElementById('load-session-file');
+
+            // --- TOAST NOTIFICATIONS ---
+            function showToast(message, type = 'success', duration = 3000) {
+                const container = document.getElementById('toast-container');
+                const toast = document.createElement('div');
+                const icon = {
+                    success: `<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`,
+                    error: `<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`,
+                    warning: `<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>`
+                };
+                toast.className = `toast toast-${type}`;
+                toast.innerHTML = `${icon[type]}<span>${message}</span>`;
+                container.appendChild(toast);
+                setTimeout(() => toast.classList.add('show'), 10);
+                setTimeout(() => {
+                    toast.classList.remove('show');
+                    toast.addEventListener('transitionend', () => toast.remove());
+                }, duration);
+            }
+
+            // --- API CALLS ---
+            async function shortenWithOuo(url, apiKey) {
+                if (!apiKey) {
+                    showToast("API Key ouo.io tidak ditemukan.", "warning");
+                    return url;
+                }
+                const apiUrl = `https://ouo.io/api/${apiKey}?s=${encodeURIComponent(url)}`;
+                try {
+                    const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(apiUrl)}`;
+                    const response = await fetch(proxyUrl);
+                    if (response.ok) {
+                        const text = await response.text();
+                        if (text.startsWith('https://ouo.io/')) return text;
+                        showToast(`Gagal memperpendek ${url}. Respon: ${text}`, 'error');
+                        return url;
+                    }
+                    showToast(`Gagal memperpendek ${url}. Status: ${response.status}`, 'warning');
+                    return url;
+                } catch (e) {
+                    showToast(`Error koneksi saat menghubungi ouo.io: ${e.message}`, 'error');
+                    return url;
+                }
+            }
+
+            // --- UI RENDERING & UPDATES ---
+            function renderResolutions() {
+                resolutionOptionsContainer.innerHTML = RESOLUTION_OPTIONS.map(res => {
+                    const id = `res-${res}`;
+                    const isChecked = state.selectedResolutions.includes(res);
+                    return `<div>
+                        <input type="checkbox" id="${id}" value="${res}" class="h-4 w-4 text-brand-primary border-slate-300 rounded focus:ring-brand-primary" ${isChecked ? 'checked' : ''}>
+                        <label for="${id}" class="ml-2 text-sm text-brand-text-secondary">${res}</label>
+                    </div>`;
+                }).join('');
+                resolutionOptionsContainer.addEventListener('change', e => {
+                    if (e.target.type === 'checkbox') {
+                        const res = e.target.value;
+                        if (e.target.checked) {
+                            if (!state.selectedResolutions.includes(res)) state.selectedResolutions.push(res);
+                        } else {
+                            state.selectedResolutions = state.selectedResolutions.filter(r => r !== res);
+                        }
+                    }
+                });
+            }
+
+            function renderServerSelect() {
+                serverNameSelect.innerHTML = SERVER_OPTIONS.map(s => `<option value="${s}">${s}</option>`).join('');
+            }
+
+            function renderServerList() {
+                const hasData = Object.keys(state.mainData).length > 0;
+                noDataMsg.classList.toggle('hidden', hasData);
+                outputSettingsContainer.classList.toggle('hidden', !hasData);
+                resultContainer.classList.add('hidden');
+
+                serverListContainer.innerHTML = '';
+                if (!hasData) return;
+
+                const serverListWithStream = ["Streaming", ...state.serverOrder];
+                serverListWithStream.forEach(serverName => {
+                    const isStream = serverName === "Streaming";
+                    const hasStreamLink = Object.values(state.mainData).some(d => d.stream_link);
+                    if (isStream && !hasStreamLink) return;
+
+                    const serverItem = document.createElement('div');
+                    serverItem.className = 'p-3 border border-brand-border rounded-lg bg-brand-surface';
+                    serverItem.dataset.serverName = serverName;
+                    const idx = state.serverOrder.indexOf(serverName);
+
+                    serverItem.innerHTML = `
+                        <div class="flex items-center gap-3 flex-wrap">
+                            <input type="checkbox" id="shorten-${serverName}" data-server="${serverName}" class="h-4 w-4 text-brand-primary border-slate-300 rounded focus:ring-brand-primary" title="Perpendek link untuk ${serverName}">
+                            <label for="shorten-${serverName}" class="font-semibold text-brand-text-primary flex-grow">${serverName}</label>
+                            ${!isStream ? `
+                            <div class="flex gap-1">
+                                <button data-action="up" class="text-sm p-1.5 bg-brand-surface hover:bg-brand-border rounded-md disabled:opacity-50" ${idx === 0 ? 'disabled' : ''} title="Naikkan">↑</button>
+                                <button data-action="down" class="text-sm p-1.5 bg-brand-surface hover:bg-brand-border rounded-md disabled:opacity-50" ${idx === state.serverOrder.length - 1 ? 'disabled' : ''} title="Turunkan">↓</button>
+                                <button data-action="delete" class="text-sm p-1.5 bg-red-100 hover:bg-red-200 text-red-700 rounded-md" title="Hapus">⌦</button>
+                            </div>` : ''}
+                        </div>`;
+                    serverListContainer.appendChild(serverItem);
+                });
+            }
+            
+            function renderOutputFormatOptions() {
+                formatOptionsRadio.innerHTML = Object.entries(OUTPUT_FORMATS).map(([key, value], index) => `
+                    <div>
+                        <input type="radio" id="format-${key}" name="output_format" value="${key}" class="h-4 w-4 text-brand-primary border-slate-300 focus:ring-brand-primary" ${index === 0 ? 'checked' : ''}>
+                        <label for="format-${key}" class="ml-2 text-sm text-brand-text-secondary">${value}</label>
+                    </div>`).join('');
+                document.querySelectorAll('input[name="output_format"]').forEach(radio => radio.addEventListener('change', updateFormatSpecificOptions));
+                updateFormatSpecificOptions();
+            }
+
+            function updateFormatSpecificOptions() {
+                const selectedFormat = document.querySelector('input[name="output_format"]:checked').value;
+                let optionsHtml = '';
+                const toggle = (id, text, checked = true) => `<label class="flex items-center"><input type="checkbox" id="${id}" class="h-4 w-4 rounded" ${checked ? 'checked' : ''}> <span class="ml-2 text-sm">${text}</span></label>`;
+                switch (selectedFormat) {
+                    case 'drakor':
+                        optionsHtml = `<div class="flex gap-4">${toggle('drakor-uppercase', 'Server Uppercase')} ${toggle('drakor-centered', 'Rata Tengah', false)}</div>`;
+                        break;
+                    case 'ringkas':
+                        optionsHtml = `
+                            <div class="flex flex-wrap gap-x-6 gap-y-3">
+                                <div class="flex items-center gap-2">
+                                    <span class="text-sm font-medium">Urutkan:</span>
+                                    <label class="flex items-center"><input type="radio" name="ringkas-group" value="server" class="h-4 w-4" checked> <span class="ml-1 text-sm">Server</span></label>
+                                    <label class="flex items-center"><input type="radio" name="ringkas-group" value="resolusi" class="h-4 w-4"> <span class="ml-1 text-sm">Resolusi</span></label>
+                                </div>
+                                ${toggle('ringkas-uppercase', 'Server Uppercase')} ${toggle('ringkas-streaming', 'Sertakan Streaming', false)}
+                            </div>`;
+                        break;
+                    case 'resolusi':
+                        optionsHtml = toggle('resolusi-uppercase', 'Server Uppercase');
+                        break;
+                }
+                formatSpecificOptions.innerHTML = optionsHtml;
+            }
+
+            function updateInputModeUI() {
+                const mode = document.querySelector('input[name="input_mode"]:checked').value;
+                episodeRangeContainer.style.display = mode === 'batch' ? 'grid' : 'none';
+                streamLinksInput.rows = mode === 'batch' ? 3 : 1;
+                streamLinksInput.placeholder = mode === 'batch' ? '1 link per baris untuk mode batch' : 'Masukkan satu link streaming';
+            }
+            
+            function updateServerNameInput() {
+                const choice = serverNameSelect.value;
+                serverNameManual.style.display = choice === SERVER_OPTIONS[0] ? 'block' : 'none';
+                if (choice === SERVER_OPTIONS[0]) serverNameManual.focus();
+                else serverNameManual.value = '';
+            }
+
+            function resetForm() {
+                streamLinksInput.value = '';
+                downloadLinksInput.value = '';
+                serverNameSelect.value = SERVER_OPTIONS[0];
+                updateServerNameInput();
+            }
+            
+            function fullReset() {
+                state = { mainData: {}, serverOrder: [], selectedResolutions: ["480p", "720p"], startEp: 1, endEp: 1 };
+                startEpInput.value = 1; endEpInput.value = 1;
+                resetForm(); renderAll();
+                localStorage.removeItem('linkGeneratorSession');
+                showToast('Semua data berhasil direset.', 'success');
+            }
+
+            // --- EVENT HANDLERS ---
+            addDataBtn.addEventListener('click', () => {
+                const downloadLinks = downloadLinksInput.value.split('\n').map(l => l.trim()).filter(Boolean);
+                const streamLinks = streamLinksInput.value.split('\n').map(l => l.trim()).filter(Boolean);
+                const mode = document.querySelector('input[name="input_mode"]:checked').value;
+                const serverName = serverNameSelect.value === SERVER_OPTIONS[0] ? serverNameManual.value.trim() : serverNameSelect.value;
+
+                if (downloadLinks.length > 0 && !serverName) return showToast('Nama Server Download tidak boleh kosong.', 'error');
+                if (downloadLinks.length > 0 && state.selectedResolutions.length === 0) return showToast('Pilih minimal satu resolusi download.', 'error');
+
+                const startEp = parseInt(startEpInput.value), endEp = parseInt(endEpInput.value);
+                const numEps = mode === 'batch' ? (endEp - startEp) + 1 : 1;
+                const episodeRange = mode === 'batch' ? Array.from({ length: numEps }, (_, i) => startEp + i) : [1];
+
+                if (mode === 'batch' && streamLinks.length > 0 && streamLinks.length !== numEps) return showToast(`Jumlah link streaming (${streamLinks.length}) tidak cocok dengan jumlah episode (${numEps}).`, 'error');
+                const expectedLinks = numEps * state.selectedResolutions.length;
+                if (downloadLinks.length > 0 && downloadLinks.length !== expectedLinks) return showToast(`Jumlah link download tidak sesuai. Diperlukan: ${expectedLinks}, Disediakan: ${downloadLinks.length}.`, 'error');
+
+                let linkIdx = 0, streamIdx = 0;
+                episodeRange.forEach(epNum => {
+                    if (!state.mainData[epNum]) state.mainData[epNum] = {};
+                    if (streamLinks[streamIdx]) {
+                        state.mainData[epNum].stream_link = streamLinks[streamIdx];
+                        streamIdx++;
+                    }
+                    if (downloadLinks.length > 0) {
+                        if (!state.mainData[epNum].download_links) state.mainData[epNum].download_links = {};
+                        state.selectedResolutions.forEach(res => {
+                            if (!state.mainData[epNum].download_links[res]) state.mainData[epNum].download_links[res] = {};
+                            state.mainData[epNum].download_links[res][serverName] = downloadLinks[linkIdx];
+                            linkIdx++;
+                        });
+                    }
+                });
+                if (downloadLinks.length > 0 && !state.serverOrder.includes(serverName)) state.serverOrder.push(serverName);
+                showToast('Data berhasil ditambahkan!', 'success');
+                resetForm(); renderAll();
+            });
+
+            serverListContainer.addEventListener('click', e => {
+                const button = e.target.closest('button');
+                if (!button) return;
+                const serverItem = e.target.closest('[data-server-name]');
+                const serverName = serverItem.dataset.serverName;
+                const action = button.dataset.action;
+                const idx = state.serverOrder.indexOf(serverName);
+
+                if (action === 'up' && idx > 0) [state.serverOrder[idx], state.serverOrder[idx - 1]] = [state.serverOrder[idx - 1], state.serverOrder[idx]];
+                else if (action === 'down' && idx < state.serverOrder.length - 1) [state.serverOrder[idx], state.serverOrder[idx + 1]] = [state.serverOrder[idx + 1], state.serverOrder[idx]];
+                else if (action === 'delete') {
+                    state.serverOrder.splice(idx, 1);
+                    Object.values(state.mainData).forEach(epData => {
+                        if (epData.download_links) Object.values(epData.download_links).forEach(resData => delete resData[serverName]);
+                    });
+                }
+                renderAll();
+            });
+
+            generateHtmlBtn.addEventListener('click', async () => {
+                const format = document.querySelector('input[name="output_format"]:checked').value;
+                const mode = document.querySelector('input[name="input_mode"]:checked').value;
+                const startEp = parseInt(startEpInput.value), endEp = parseInt(endEpInput.value);
+                const episodeRange = mode === 'batch' ? Array.from({ length: (endEp - startEp) + 1 }, (_, i) => startEp + i) : [1];
+                const serversToShorten = Array.from(serverListContainer.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.dataset.server);
+                const apiKey = ouoApiKeyInput.value;
+                let finalHtml = '';
+
+                showToast('Memproses dan memperpendek link...', 'success');
+                
+                switch (format) {
+                    case 'drakor':
+                        finalHtml = await generateOutputDrakor(episodeRange, document.getElementById('drakor-uppercase').checked, document.getElementById('drakor-centered').checked, serversToShorten, apiKey);
+                        break;
+                    case 'ringkas':
+                        finalHtml = await generateOutputRingkas(episodeRange, document.querySelector('input[name="ringkas-group"]:checked').value, document.getElementById('ringkas-uppercase').checked, document.getElementById('ringkas-streaming').checked, serversToShorten, apiKey);
+                        break;
+                    case 'resolusi':
+                        finalHtml = await generateOutputResolusi(episodeRange, document.getElementById('resolusi-uppercase').checked, serversToShorten, apiKey);
+                        break;
+                }
+                resultHtmlTextarea.value = finalHtml;
+                resultPreview.innerHTML = finalHtml;
+                resultContainer.classList.remove('hidden');
+            });
+            
+            copyHtmlBtn.addEventListener('click', () => {
+                resultHtmlTextarea.select();
+                document.execCommand('copy');
+                showToast('HTML berhasil disalin!', 'success');
+            });
+
+            // --- HTML GENERATION LOGIC (simplified for brevity, logic is the same) ---
+            async function generateOutputDrakor(epRange, upper, centered, shorten, apiKey) {
+                let lines = []; const style = centered ? ' style="text-align: center;"' : '';
+                for (const ep of epRange) {
+                    if (!state.mainData[ep]) continue;
+                    if (epRange.length > 1) lines.push(`<p${style}><strong>EPISODE ${ep}</strong></p>`);
+                    const links = state.mainData[ep].download_links || {};
+                    for (const res of state.selectedResolutions) {
+                        if (!links[res]) continue;
+                        let parts = [];
+                        for (const srv of state.serverOrder) {
+                            if (links[res][srv]) {
+                                let url = await (shorten.includes(srv) ? shortenWithOuo(links[res][srv], apiKey) : Promise.resolve(links[res][srv]));
+                                parts.push(`<a href="${url}">${upper ? srv.toUpperCase() : srv}</a>`);
+                            }
+                        }
+                        if (parts.length > 0) lines.push(`<p${style}><strong>${res} (Hardsub Indo):</strong> ${parts.join(" | ")}</p>`);
+                    }
+                }
+                return lines.join('\n');
+            }
+            async function generateOutputRingkas(epRange, group, upper, stream, shorten, apiKey) {
+                let lines = [];
+                for (const ep of epRange) {
+                    if (!state.mainData[ep]) continue;
+                    let parts = [];
+                    if (stream && state.mainData[ep].stream_link) {
+                        let url = await (shorten.includes("Streaming") ? shortenWithOuo(state.mainData[ep].stream_link, apiKey) : Promise.resolve(state.mainData[ep].stream_link));
+                        parts.push(`<a href="${url}">Streaming</a>`);
+                    }
+                    const dLinks = state.mainData[ep].download_links || {};
+                    const outer = group === 'server' ? state.serverOrder : state.selectedResolutions;
+                    const inner = group === 'server' ? state.selectedResolutions : state.serverOrder;
+                    for (const o of outer) {
+                        for (const i of inner) {
+                            const res = group === 'server' ? i : o; const srv = group === 'server' ? o : i;
+                            if (dLinks[res] && dLinks[res][srv]) {
+                                let url = await (shorten.includes(srv) ? shortenWithOuo(dLinks[res][srv], apiKey) : Promise.resolve(dLinks[res][srv]));
+                                parts.push(`<a href="${url}" rel="nofollow" data-wpel-link="external">${upper ? srv.toUpperCase() : srv} ${res}</a>`);
+                            }
+                        }
+                    }
+                    if (parts.length > 0) lines.push(`<li><strong>EPISODE ${ep}</strong> ${parts.join(' ')}</li>`);
+                }
+                return `<ul>\n${lines.join('\n')}\n</ul>`;
+            }
+            async function generateOutputResolusi(epRange, upper, shorten, apiKey) {
+                let lines = [];
+                for (const ep of epRange) {
+                    if (!state.mainData[ep] || !state.mainData[ep].download_links) continue;
+                    if (epRange.length > 1) lines.push(`<li><strong>EPISODE ${ep}</strong></li>`);
+                    for (const res of state.selectedResolutions) {
+                        if (!state.mainData[ep].download_links[res]) continue;
+                        let parts = [`<strong>${res}</strong>`];
+                        for (const srv of state.serverOrder) {
+                            if (state.mainData[ep].download_links[res][srv]) {
+                                let url = await (shorten.includes(srv) ? shortenWithOuo(state.mainData[ep].download_links[res][srv], apiKey) : Promise.resolve(state.mainData[ep].download_links[res][srv]));
+                                parts.push(`<a href="${url}" rel="nofollow" data-wpel-link="external">${upper ? srv.toUpperCase() : srv}</a>`);
+                            }
+                        }
+                        if (parts.length > 1) lines.push(`<li>${parts.join(' ')}</li>`);
+                    }
+                }
+                return `<ul>\n${lines.join('\n')}\n</ul>`;
+            }
+
+            // --- SESSION SAVE/LOAD ---
+            saveSessionBtn.addEventListener('click', () => {
+                state.startEp = parseInt(startEpInput.value); state.endEp = parseInt(endEpInput.value);
+                const data = JSON.stringify(state, null, 2);
+                const url = URL.createObjectURL(new Blob([data], { type: 'application/json' }));
+                const a = document.createElement('a');
+                a.href = url; a.download = `link_generator_session_${new Date().toISOString().slice(0, 19).replace(/[-T:]/g, "")}.json`;
+                a.click(); URL.revokeObjectURL(url);
+                showToast('File sesi siap diunduh.', 'success');
+            });
+            loadSessionFile.addEventListener('change', (event) => {
+                const file = event.target.files[0]; if (!file) return;
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    try {
+                        const loaded = JSON.parse(e.target.result);
+                        if (loaded.mainData && loaded.serverOrder && loaded.selectedResolutions) {
+                            state = loaded;
+                            startEpInput.value = state.startEp || 1; endEpInput.value = state.endEp || 1;
+                            renderAll(); showToast('Sesi berhasil dimuat!', 'success');
+                        } else showToast('File JSON tidak valid.', 'error');
+                    } catch (err) { showToast(`Gagal memuat: ${err.message}`, 'error'); }
+                };
+                reader.readAsText(file); event.target.value = '';
+            });
+
+            // --- INITIALIZATION ---
+            function renderAll() {
+                renderServerList(); renderResolutions(); renderOutputFormatOptions();
+                updateInputModeUI(); updateServerNameInput();
+            }
+            inputModeRadios.forEach(radio => radio.addEventListener('change', updateInputModeUI));
+            serverNameSelect.addEventListener('change', updateServerNameInput);
+            resetAllBtn.addEventListener('click', fullReset);
+            renderServerSelect(); renderAll();
+        });
+    </script>
+</body>
+</html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,6 +37,12 @@ const Header: React.FC = () => {
             <NavLink to="/discover/tv" className={navLinkClass}>
               Acara TV
             </NavLink>
+            <a
+              href="/tools.html"
+              className="pb-1 border-b-2 border-transparent text-brand-text-secondary hover:text-brand-text-primary transition-colors"
+            >
+              Tools
+            </a>
           </nav>
         </div>
         <div className="w-full md:w-auto flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add standalone Tools page with a full-featured universal link generator
- link Tools page from main header navigation
- redesign Tools page to use site branding and include the site navbar

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any, etc.)*
- `nohup npm run dev -- --host 127.0.0.1 --clearScreen false >/tmp/dev.log 2>&1 &` *(killed after testing)*
- `curl -s http://127.0.0.1:5174/tools.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689751f59f2c832ab3529032b3849473